### PR TITLE
refactor: getImagePathList内の使用関数を変更

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -5,31 +5,28 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
 func getImagePathList(dir string) []string {
-    names := []string{}
-    file, err := os.Open(dir)
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer file.Close()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    files, err := file.Readdir(-1)
-    if err != nil {
-        log.Fatal(err)
-    }
-    for _, f := range files {
-        if !f.IsDir() {
-            ext := strings.ToLower(filepath.Ext(f.Name()))
-            if ext == ".png" || ext == ".jpg" || ext == ".jpeg" {
-                names = append(names, f.Name())
-            }
-        }
-    }
-
-    return names
+	filenames := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filename := entry.Name()
+		ext := filepath.Ext(filename)
+		if slices.Contains([]string{".png", ".jpg", ".jpeg"}, strings.ToLower(ext)) {
+			filenames = append(filenames, filename)
+		}
+	}
+	return filenames
 }
 
 func main() {


### PR DESCRIPTION
`getImagePathList`内の使用関数を変更し、全体的な見通しを良くします。

- ディレクトリのファイル取得は`os.Open`を使わずに`os.ReadDir`でショートカットできます
- extの判定に`slices.Contains`を使います
- 否定文脈の`!`を`continue`に変更し、後続メイン処理にかかるネストを消します

全体的な処理の期待結果には変化はありません。