### PR TITLE
feat: CLIツールとして使えるようにする

### DIFF
--- a/src/io.go
+++ b/src/io.go
@@ -7,6 +7,7 @@ import (
 	"image/png"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 var IMAGE_SIZES = []int{64, 180, 192, 512}
@@ -26,6 +27,7 @@ func loadImage(path string) image.Image {
 }
 
 func saveImage(path string, img image.Image) {
+	_ = os.MkdirAll(filepath.Dir(path), os.ModePerm)
 	for _, size := range IMAGE_SIZES {
 		file, err := os.Create(fmt.Sprintf("%s_%d.png", path, size))
 		if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -33,12 +34,30 @@ func getImagePathList(dir string) []string {
 }
 
 func main() {
-    imagePathList := getImagePathList("source")
+	flag.Usage = func() {
+		help := `Usage: %s [options]
 
-    for _, path := range imagePathList {
-        img := loadImage("source/" + path)
-        ext := filepath.Ext(path)
-        saveImage("output/" + strings.TrimSuffix(path, ext), img)
-    }
-    fmt.Println("Done")
+Description:
+  正方形画像を角丸にして、アイコン用の複数サイズに変換します
+
+Options:
+`
+		fmt.Fprintf(flag.CommandLine.Output(), help, filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	var (
+		srcP = flag.String("i", "source", "ソースディレクトリ。正方形の画像(png/jpg)を入れる")
+		dstP = flag.String("o", "output", "出力ディレクトリ。加工後の画像が生成される")
+	)
+	flag.Parse()
+	src, dst := *srcP, *dstP
+
+	imagePathList := getImagePathList(src)
+
+	for _, filename := range imagePathList {
+		img := loadImage(filepath.Join(src, filename))
+		stem := strings.TrimSuffix(filename, filepath.Ext(filename))
+		saveImage(filepath.Join(dst, stem), img)
+	}
+	fmt.Println("Done")
 }


### PR DESCRIPTION
オプション解析を追加しました。
ビルドしたバイナリを`PATH`が通っている場所に置けば、汎用的に使えるようになるので良いかと思います。
また、ヘルプが付きます。

このPRの変更により、ビルドしたバイナリは次のようにも使えるようになります。

```bash
icon-maker -i source_dir -o fuga_dir
```

オプションを特に指定しない場合は、デフォルトで`source`, `output`を参照するので元の挙動のままです。

## 追加事項

次の部分を変更しています。

- 出力先ディレクトリが存在しない場合は作成する
  - 入力先を作るのは良いのですが、出力先をわざわざ作ってからでないと動かないのは、使い勝手がよく無さそうに感じた為です
- ファイルパス結合に`filepath.Join`を使う
  - パスがOSに応じてうまい具合にクリンナップされる他、単純な文字列結合より見栄えも良くなるんじゃないかと思います